### PR TITLE
認証のcru　apiとfront

### DIFF
--- a/app/backend/api/models/users.py
+++ b/app/backend/api/models/users.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, Boolean
+from sqlalchemy.orm import relationship
+
+from api.db import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(254), nullable=True)
+    email = Column(String(254), unique=True, nullable=False)
+    hashed_password = Column(String(72), unique=True, nullable=False)
+    disabled = Column(Boolean, default=False, nullable=False)
+    admin = Column(Boolean, default=False, nullable=False)
+
+
+#reservations = relationship("Reservation", back_populates="user_id")

--- a/app/backend/api/routers/auth.py
+++ b/app/backend/api/routers/auth.py
@@ -1,54 +1,81 @@
+from api.db import get_db
 from datetime import datetime, timedelta
-from typing import Union
+from typing import Union, Optional,Tuple,List
 
 from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from jose import JWTError, jwt
 from passlib.context import CryptContext
-from pydantic import BaseModel
-from fastapi import APIRouter
+from pydantic import BaseModel,Field
+from fastapi import APIRouter, Depends
 
+# crud
+import api.models.users as users_model
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select,update
+from sqlalchemy.engine import Result
 router = APIRouter()
 
 # to get a string like this run:
 # openssl rand -hex 32
-# JWTトークンの署名?
+# settingに記載する
 SECRET_KEY = "09d25e094faa6ca2556c818166b7a9563b93f7099f6f0f4caa6cf63b88e8d3e7"
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
-
-
-fake_users_db = {
-    "johndoe": {
-        "username": "johndoe",
-        "full_name": "John Doe",
-        "email": "johndoe@example.com",
-        "hashed_password": "$2b$12$EixZaYVK1fsbw1ZfbX3OXePaWxn96p36WQoeG6Lruj3vjPGga31lW",
-        "disabled": False,
-    }
-}
-
-# レスポンスのトークンエンドポイントで使用するPydanticモデル
 
 
 class Token(BaseModel):
     access_token: str
     token_type: str
 
+    class Config:
+      orm_mode = True
 
 class TokenData(BaseModel):
     username: Union[str, None] = None
 
-
+    class Config:
+      orm_mode = True
+# emailとpasswordは必須
 class User(BaseModel):
-    username: str
-    email: Union[str, None] = None
-    full_name: Union[str, None] = None
-    disabled: Union[bool, None] = None
+    id: int
+    name: Union[str, None] = None
+    email: str
+    hashed_password: str 
+    disabled:  bool
+    admin: bool
 
+    class Config:
+      orm_mode = True
 
 class UserInDB(User):
     hashed_password: str
+
+    class Config:
+      orm_mode = True
+
+class UserCreate(BaseModel):
+    name: str = Field(example="johndoe")
+    email: str = Field(example="johndoe@example.com")
+    #password: str = Field(example="password")
+    password: str = Field(example="secret")
+    # disabled: bool 
+    # admin: bool 
+
+    class Config:
+      orm_mode = True
+
+
+class UserPutDisabled(BaseModel):
+    # name: str = Field(example="johndoe")
+    # email: str = Field(example="johndoe@example.com")
+    # password: str = Field(example="password")
+    # password: str = Field(example="secret")
+    disabled: bool
+    # admin: bool
+    class Config:
+      orm_mode = True
+
 
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -64,35 +91,44 @@ app = FastAPI()
 def verify_password(plain_password, hashed_password):
     return pwd_context.verify(plain_password, hashed_password)
 
-# 送られてきたpasswordをハッシュする...どこにつながってる？
 
 
 def get_password_hash(password):
     return pwd_context.hash(password)
 
-# dbから対象のusernameのレコードを取得する
 
 
-def get_user(db, username: str):
-    # dbとの接続
-    if username in db:
-        user_dict = db[username]
-        # 対象userのuser情報が返ってくる
-        print("user_dict",user_dict) 
-        return UserInDB(**user_dict)
-
-# dbから取得したuser情報を返す
-def authenticate_user(fake_db, username: str, password: str):
-    user = get_user(fake_db, username)
-    print("authenticate_user",username, password)
-    if not user:
-        return False
-    if not verify_password(password, user.hashed_password):
-        return False
+async def get_user(email: str, db):
+    print("通過", email)
+    result: Result = await db.execute(
+        select(users_model.User.id,
+               users_model.User.name,
+               users_model.User.email,
+               users_model.User.hashed_password,
+               users_model.User.disabled,
+               users_model.User.admin,
+               )
+        .filter(
+            users_model.User.email == email)
+    )
+    print("result",result)
+    # resultのtupleをdictionaryに変換
+    keys = ('id', 'name', 'email', 'hashed_password', 'disabled', 'admin')
+    user = dict(zip(keys, result.first()))
+    print("id",user['id'])
     return user
 
-# 新しいアクセストークンを作成する
-# dictとは何だ？Unionって何だ？
+# dbから取得したuser情報を返す
+async def authenticate_user(db, email: str, password: str):
+    print("authenticate_user通過","username",email, "password",password)
+    user = await get_user(email, db)
+    print("userの中身", user['hashed_password'])
+    if not user:
+        return False
+    if not verify_password(password, user['hashed_password']):
+        return False
+    print("validation_passed")
+    return user
 
 
 def create_access_token(data: dict, expires_delta: Union[timedelta, None] = None):
@@ -102,70 +138,128 @@ def create_access_token(data: dict, expires_delta: Union[timedelta, None] = None
     else:
         expire = datetime.utcnow() + timedelta(minutes=15)
     to_encode.update({"exp": expire})
-    # jwt.encodeとは？公開鍵作成？
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 
 # クライアントから送られてきたtokenを検証する
-async def get_current_user(token: str = Depends(oauth2_scheme)):
-    # falseだったらこれ返す
+async def get_current_user(token: str = Depends(oauth2_scheme),db: AsyncSession = Depends(get_db)):
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
         headers={"WWW-Authenticate": "Bearer"},
     )
     print("token",token)
-    # jwtのdecode 復元ぽいな
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        username: str = payload.get("sub")
-        if username is None:
+        print("payload",payload)
+        email: str = payload.get("sub")
+        print("useremail入ってほしい",email)
+        if email is None:
             raise credentials_exception
-        token_data = TokenData(username=username)
+        token_data = TokenData(username=email)
     except JWTError:
         print("JWTError")
         raise credentials_exception
-    user = get_user(fake_users_db, username=token_data.username)
+    email = token_data.username
+    # user = get_user(db, email=token_data.username)
+    user = await get_user(email, db)
     if user is None:
         raise credentials_exception
+    print("get_current_user", user)
     return user
 
 # userテーブルのdisabledレコードがtrueなら
-
-
 async def get_current_active_user(current_user: User = Depends(get_current_user)):
-    if current_user.disabled:
+    print("current_user",current_user)
+    if current_user['disabled'] == True:
         raise HTTPException(status_code=400, detail="Inactive user")
     return current_user
 
-# tokenurl＝tokenに来たログイン情報を認証してアクセストークンを発行してフロントに返却
-
-
+# ログイン情報を認証してアクセストークンを発行してフロントに返却
 @router.post("/token", response_model=Token)
-async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends()):
-    user = authenticate_user(
-        fake_users_db, form_data.username, form_data.password)
+async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(), db: AsyncSession = Depends(get_db)):
+    print("通過通過",form_data.username)
+    # form_dataのkeyはusernameで固定
+    email = form_data.username
+    password = form_data.password
+    user = await authenticate_user(
+        db, email, password)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
             headers={"WWW-Authenticate": "Bearer"},
         )
+    print("create_access_token前")
     access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     access_token = create_access_token(
-        data={"sub": user.username}, expires_delta=access_token_expires
+        data={"sub": user['email']}, expires_delta=access_token_expires
     )
+    print("create_access_token後")
+    print("tokenを返している",access_token)
     return {"access_token": access_token, "token_type": "bearer"}
 
-# 自分の頁を見に来ている
+
 @router.get("/users/me/", response_model=User)
-# read_users_meって何？
 async def read_users_me(current_user: User = Depends(get_current_active_user)):
     return current_user
 
 
-# 自分のitemを見に来ている
-@router.get("/users/me/items/")
-# read_own_itemsって何？
-async def read_own_items(current_user: User = Depends(get_current_active_user)):
-    return [{"item_id": "Foo", "owner": current_user.username}]
+#新規登録
+@router.post("/register")
+# crud
+async def create_user(
+    user_body: UserCreate, db: AsyncSession = Depends(get_db)
+    ) -> users_model.User:
+    print("user_body",user_body)
+    hashed_password = get_password_hash(user_body.password)
+    print("hashed_password", hashed_password)
+    create_data = {
+        "name": user_body.name,
+        "email": user_body.email,
+        "hashed_password": hashed_password,
+    # 以下は一旦falseで
+        "disabled": False,
+        "admin": False
+    }
+    print("create_data", create_data)
+    user = users_model.User(**create_data)
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+# crud
+async def crud_update_task(
+    user_update: UserPutDisabled,
+    original: users_model.User,
+    db: AsyncSession = Depends(get_db)
+    ) -> users_model.User:
+    
+    print("crud_update_task",original['id'])
+
+    db_user = await db.get(users_model.User, original['id'])
+    test = user_update.dict(exclude_unset=True)
+    for key, value in test.items():
+        setattr(db_user, key, value)
+    db.add(db_user)
+    await db.commit()
+    await db.refresh(db_user)
+    return db_user
+
+# 退会押下でdisabledをTrueに更新
+@router.put("/users/me/")
+async def update_user(
+    user_body: UserPutDisabled, 
+    current_user: User = Depends(get_current_active_user), 
+    db: AsyncSession = Depends(get_db), 
+    ):
+    print("user_body.disabled", user_body.disabled)
+    print("current_user", current_user)
+    #crud update_user
+    original = current_user
+    return await crud_update_task(user_body, original, db)
+
+
+
+

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import "./App.css";
 import { Route, Routes } from "react-router-dom";
 import SignIn from "./pages/SignIn";
+import SignUp from "./pages/SignUp";
 import MyPage from "./pages/Mypage";
 import Header from "./components/Header"
 import Home from "./pages/Home";
@@ -18,6 +19,7 @@ const App = (): JSX.Element => {
         </header>
         <Routes>
           <Route path="/signin" element={<SignIn />} />
+          <Route path="/signup" element={<SignUp />} />
           <Route path="/mypage" element={<MyPage />} />
           <Route path="/" element={<Home />} />
         </Routes>

--- a/app/frontend/src/components/Header.tsx
+++ b/app/frontend/src/components/Header.tsx
@@ -13,8 +13,6 @@ export default function ButtonAppBar()
     const { user, logout } = useAuth()
     const navigate = useNavigate();
     
-  console.log(logout)
-  console.log(user)
   const handleHome = () => navigate("/")
   const handleSignin = () => navigate("/signin")
   const handleMyPage = () => navigate("/mypage");

--- a/app/frontend/src/context/auth.tsx
+++ b/app/frontend/src/context/auth.tsx
@@ -9,33 +9,16 @@ export const useAuth = () => useContext(AuthContext)
 export const AuthProvider = (props:any) =>
 {
   const [user, setUser] = useState<any>(null);
-  console.log("auth.tsx,user",user)
+  //loading中はloading画面を表示したいけど上手くいかないので保留
+  const [ isLoading, setLoading ] = useState<boolean>(true)
   const navigate = useNavigate();
   
-  //tokenあり->apiからuser情報を取得。
-  // const isAuthenticated = () =>
-  // {
-  //   console.log("isAuthenticated実行")
-  //   const token:any = localStorage.getItem("token")
-  //             if (token) {
-  //           const headers = {
-  //             Authorization: `Bearer ${token}`,
-  //           };
-  //           axios
-  //             .get("http://localhost:8080/users/me", { headers })
-  //             .then((res) => setUser(res.data));
-  //         } else {
-  //               setUser(null)
-  //               navigate("/signin");
-  //         }
-  // }
-  
-
-    useEffect(() =>
-    {
-      const token = localStorage.getItem("token")
-      console.log(token)
-        const isAuthenticated = () => {
+  const isAuthenticated = () =>
+  {
+    setLoading(false);
+    console.log("isAuthenticated", isLoading);
+    const token = localStorage.getItem("token")
+    console.log(token)
           if (token) {
             const headers = {
               Authorization: `Bearer ${token}`,
@@ -45,48 +28,68 @@ export const AuthProvider = (props:any) =>
               .then((res) => setUser(res.data));
           } else {
             setUser(null);
-          }
-        };
-        //  isAuthenticated()
-        return isAuthenticated;
-    },[]);
-    
-  //login情報をapi送付し、apiから送付されたtokenをlocalStorageにセットする
-    const login = async (useName:any,password:any) => {
-        const params = new URLSearchParams();
-        params.append("username", useName);
-        params.append("password", password);
-
-        const config = {
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded"
-          }
-        }
-
-        const response:any =  await axios
-          .post("http://localhost:8080/token", params, config)
-          .then((res) =>  res.data);
-          
-          const token = response.access_token
-          if (token)
-          {
-            localStorage.setItem("token", token);
-        }
+            navigate("/signin")
+    }
   }
   
-  console.log(localStorage)
-  //logout
-    const logout = () =>
-    {
-      localStorage.removeItem("token")
-      setUser(null)
-      //
-      navigate("/signin")
+  console.log("isLoading", isLoading)
+  console.log(user)
+
+  const isRegister = async (userName: string, email: string, password: string) =>
+  {
+    const body = {
+      name: userName,
+      email: email,
+      password: password
     }
+
+    await axios
+      .post("http://localhost:8080/register", body)
+      .then((res) => res.data)
+  }
+  
+  //login情報をapi送付し、apiから送付されたtokenをlocalStorageにセットする
+  const login = async (email:any,password:any) => {
+    const params = new URLSearchParams();
+    params.append("username", email);
+    params.append("password", password);
+    const config = {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      }
+    }
+    const response: any = await axios
+      .post("http://localhost:8080/token", params, config)
+      .then((res: any) =>
+      {
+        console.log("res",res)
+        console.log("token", res.data.access_token);
+        localStorage.setItem("token", res.data.access_token)
+        console.log(localStorage)
+      });
+    // const token = response.data.access_token
+
+    // if (token)
+    // {
+    //   localStorage.setItem("token", token);
+    //   console.log(localStorage)
+    // }
+  }
+  
+  const logout = () =>
+  {
+    localStorage.removeItem("token")
+    setUser(null)
+    //
+    navigate("/signin")
+  }
     
   return (
-    <AuthContext.Provider value={{ user, login, logout }}>
-      {user === undefined? <h1>loading</h1> : props.children }
+    <AuthContext.Provider
+      value={{ user, login, logout, isAuthenticated, isRegister, isLoading }}
+    >
+      {/* {isLoading ? <h1>loading</h1> : props.children} */}
+      {props.children}
     </AuthContext.Provider>
   );
 }

--- a/app/frontend/src/pages/Mypage.tsx
+++ b/app/frontend/src/pages/Mypage.tsx
@@ -2,18 +2,54 @@ import React, { useEffect,useState } from "react";
 import { useForm, Resolver } from "react-hook-form";
 import axios from "axios";
 import { useAuth } from "./../context/auth"
+import Button from "@mui/material/Button";
+import { handleBreakpoints } from "@mui/system";
+
 
 
 const MyPage: React.FC = () => {
     
-    const { user } = useAuth()
-    console.log(user)
+    const { user, isAuthenticated, isLoading } = useAuth();
+    
 
+  useEffect (() =>
+  {
+    isAuthenticated();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+   console.log(isLoading);
+  
+  const handlePutDisabled = () =>
+  {
+    const token = localStorage.getItem("token")
+    if (token)
+    {
+    
+      const body = { disabled: "true" }
+     
+      const config = {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      }
+      axios
+        .put("http://localhost:8080/users/me", body, config)
+        .then((res) => console.log(res));
+    }
+  }
+  
   return (
     <>
       <div className="App">
         <h1>Mypage</h1>
-        {/* <h1>{user.username}</h1> */}
+        {user && (
+          <div>
+            <h1>{user.name}</h1>
+            <h1>{user.email}</h1>
+            <Button onClick={handlePutDisabled}>退会</Button>
+          </div>
+        )}
       </div>
     </>
   );

--- a/app/frontend/src/pages/SignIn.tsx
+++ b/app/frontend/src/pages/SignIn.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useForm, Resolver } from "react-hook-form";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
@@ -26,8 +26,9 @@ const resolver: Resolver<FormValues> = async (values) => {
 
 const SignIn: React.FC = () =>
 {
-  const {user,login,isAuthenticated} = useAuth()
+  const { user, login, isAuthenticated } = useAuth();
   const navigate = useNavigate();
+  const [message,setMessage] = useState("")
 
   // console.log(isAuthenticated);
 
@@ -38,23 +39,28 @@ const SignIn: React.FC = () =>
   } = useForm<FormValues>({
     resolver: resolver,
   });
-  const onSubmit = handleSubmit(async (data) =>
-  {
+  const onSubmit = handleSubmit(async (data) => {
     await login(data.useName, data.password)
-      // .then(() => isAuthenticated())
-      .then(() =>  navigate("/mypage"))
-      .catch((e: any) => console.log(e))
+      .then((res:any) =>
+      {
+        console.log("pass")
+        navigate("/mypage")
+      })
+      .catch((e: any) =>
+      {
+        setMessage("emailもしくはpasswordの入力誤り、あるいは退会されています")
+      });
   });
 
-  //johndoe secret
+  //test@example.com test
   return (
     <>
       <div className="App">
         <h1>SignIn</h1>
         <form onSubmit={onSubmit}>
           <div>
-            <label>User Name</label>
-            <input {...register("useName")} placeholder="useName" />
+            <label>email Address </label>
+            <input {...register("useName")} placeholder="email address" />
             {errors?.useName && <p>{errors.useName.message}</p>}
           </div>
 
@@ -65,6 +71,7 @@ const SignIn: React.FC = () =>
 
           <input type="submit" />
         </form>
+        {message}
       </div>
     </>
   );

--- a/app/frontend/src/pages/SignUp.tsx
+++ b/app/frontend/src/pages/SignUp.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from "react";
+import { useForm, Resolver } from "react-hook-form";
+import axios from "axios";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../context/auth"
+// import style from "./../ styles / SignIn.module.css";
+
+type FormValues = {
+  userName: string;
+  email: string,
+  password: string;
+};
+
+const resolver: Resolver<FormValues> = async (values) => {
+  return {
+    values: !values.userName || !values.email || !values.password ? {} : values,
+    errors:
+      !values.userName || !values.email || !values.password
+        ? {
+            userName: {
+              type: "required",
+              message: "This is required.",
+            },
+          }
+        : {},
+  };
+};
+
+const SignUp: React.FC = () =>
+{
+  const { user, login, isAuthenticated, isRegister } = useAuth();
+  const navigate = useNavigate();
+  const [message,setMessage] = useState("")
+
+  // console.log(isAuthenticated);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: resolver,
+  });
+  const onSubmit = handleSubmit(async (data) =>
+  {
+    const navigateFn = () =>
+    {
+      navigate("/signin")
+    }
+    isRegister(data.userName, data.email, data.password)
+      .then((res: any) => setMessage("登録しました"))
+      .then(() => setTimeout(navigateFn, 1000));
+  });
+
+  //test@example.com test
+  return (
+    <>
+      <div className="App">
+        <h1>Sign up</h1>
+        <form onSubmit={onSubmit}>
+          <div>
+            <label>Your Name </label>
+            <input {...register("userName")} placeholder="email address" />
+            {/* {errors?.userName && <p>{errors.userName.message}</p>} */}
+          </div>
+          <div>
+            <label>email Address </label>
+            <input {...register("email")} placeholder="email address" />
+            {/* {errors?.email && <p>{errors.email.message}</p>} */}
+          </div>
+          <div>
+            <label>Password </label>
+            <input {...register("password")} placeholder="password" />
+            {errors && <p>{errors.userName?.message}</p>}
+          </div>
+          <input type="submit" />
+        </form>
+        {message}
+      </div>
+    </>
+  );
+}
+
+export default SignUp


### PR DESCRIPTION
・create 　http://localhost:3000/signup でユーザ情報入力して登録。登録後signin画面に遷移
・put signin後のmypageでユーザ情報表示。退会ボタン押下でuser_tableのdisabled=Trueに変更

signinとsignupでheaderが表示されていますが、こちらなくします

signup画面からuser情報登録できますので挙動確認したりされる場合はお使いください

![image](https://user-images.githubusercontent.com/107560126/210664177-95ba1cb3-4c49-4365-83f4-f79fb5580d1b.png)
![image](https://user-images.githubusercontent.com/107560126/210664283-dcff2036-700e-4c37-9ed9-9d357b62da77.png)
![image](https://user-images.githubusercontent.com/107560126/210664488-9825189c-da2d-4821-8265-2ef9a4dfe733.png)


